### PR TITLE
fix(skill-scout): Gemini 모델 우선순위 + 429 회로차단기

### DIFF
--- a/.github/scripts/classify-skill.mjs
+++ b/.github/scripts/classify-skill.mjs
@@ -17,12 +17,25 @@ import { fileURLToPath } from 'url';
 
 // ── Gemini API with retry + model fallback ──────────────────────────────────
 
-const MODELS = ['gemini-2.0-flash', 'gemini-2.0-flash-lite', 'gemini-2.5-flash-lite'];
+// 모델 순서: 무료 티어에서 실제로 응답하는 모델을 1순위로 둔다.
+// 2.0-flash / 2.0-flash-lite는 2026-05 기준 free tier RPM이 사실상 0으로 떨어져
+// 모든 호출이 429를 반환하므로 fallback 후순위로 격하.
+const MODELS = ['gemini-2.5-flash-lite', 'gemini-2.5-flash', 'gemini-2.0-flash-lite'];
 const MAX_RETRIES = 3;
 const FETCH_TIMEOUT_MS = 60_000; // 단일 fetch hang 방지
+// 동일 모델이 연속 429를 N회 받으면 이번 run에서 해당 모델 영구 skip.
+// 죽은 모델에 매번 3 × 60s 낭비하는 패턴을 차단한다.
+const CIRCUIT_BREAKER_THRESHOLD = 2;
+
+const dead_models = new Set();
 
 async function callGeminiWithRetry(apiKey, prompt) {
   for (const model of MODELS) {
+    if (dead_models.has(model)) {
+      console.log(`  ⏭️  ${model} skipped (circuit-breaker tripped this run)`);
+      continue;
+    }
+    let consecutive429 = 0;
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -42,6 +55,12 @@ async function callGeminiWithRetry(apiKey, prompt) {
         );
 
         if (response.status === 429) {
+          consecutive429++;
+          if (consecutive429 >= CIRCUIT_BREAKER_THRESHOLD) {
+            dead_models.add(model);
+            console.log(`  🚫 ${model}: ${consecutive429}회 연속 429 → 이번 run에서 영구 skip`);
+            break;
+          }
           const body = await response.text();
           const delayMatch = body.match(/"retryDelay":\s*"(\d+)s"/);
           const waitSec = delayMatch ? parseInt(delayMatch[1]) + 10 : Math.min(60 * attempt, 120);


### PR DESCRIPTION
## 문제 (검증 완료)

최근 2회 자동 실행이 모두 실패하며 신규 스킬이 main에 머지되지 않는 상태:
- [Skill Scout #25654316865](https://github.com/J-nowcow/awesome-korean-agent-skills/actions/runs/25654316865) (2026-05-11 정기) — FAIL
- [Skill Scout #25631705526](https://github.com/J-nowcow/awesome-korean-agent-skills/actions/runs/25631705526) (2026-05-10 수동) — FAIL

### 원인

`MODELS = ['gemini-2.0-flash', 'gemini-2.0-flash-lite', 'gemini-2.5-flash-lite']` 순서 + 무료 티어 quota:

1. 2.0-flash, 2.0-flash-lite는 매 호출 HTTP 429 반환 (free tier RPM 사실상 0)
2. 후보당 ~6분(3 × 60s × 2 모델) 대기 후에야 작동하는 2.5-flash-lite로 fallback
3. 30개 후보 처리 예정인데 60분 step timeout 안에 10~11개만 분류됨
4. step 실패 종료 → `Check for changes` 이하 단계 모두 skip → git push, PR 생성 안 됨
5. `known-repos.json`도 갱신 안 되니 다음 주에 동일 후보 또 처리 (무한 루프)

## 변경사항

**`.github/scripts/classify-skill.mjs`만 수정** (21줄 변경):

1. `MODELS` 순서 재정렬: `2.5-flash-lite → 2.5-flash → 2.0-flash-lite`
   - 실제 free tier에서 응답하는 모델을 1순위로
2. 회로차단기 추가: 동일 모델이 2회 연속 429 받으면 이번 run에서 영구 skip
   - 죽은 모델에 매 후보마다 재시도 낭비 차단

## 기대 효과

- 후보당 처리 시간: ~6분 → ~2초
- 30개 후보 5분 내 전부 분류 완료
- step timeout 도달 전에 commit/push/PR 생성 단계 정상 도달

## 검증 방법

머지 후 Actions 탭에서 `Run workflow` 버튼으로 `Skill Scout` 수동 실행:
- 로그에서 `Gemini API: model=gemini-2.5-flash-lite, attempt=1/3` 바로 성공 확인
- 60분 step timeout 도달 없이 30개 전부 처리되는지 확인
- 신규 스킬 PR(`auto/skill-scout-YYYY-MM-DD`) 자동 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)