### PR TITLE
ThreeUI 설치 스킬 추가

### DIFF
--- a/categories/web-frontend.md
+++ b/categories/web-frontend.md
@@ -44,6 +44,7 @@
 | impeccable-lite | CC/GC | AI 디자인 품질 향상 스킬 | 영+한 | [impeccable-lite](https://github.com/ilindaniel/impeccable-lite) |
 | auteur | CC/GC | 웹사이트를 영화처럼 연출하는 Claude Code 스킬 | 영+한 | [auteur](https://github.com/agiwhitelist/auteur) |
 | threejs-skills | CC | Claude Code를 위한 Three.js 스킬 모음 | 영+한 | [threejs-skills](https://github.com/CloudAI-X/threejs-skills) |
+| threeui | CX/CR | ThreeUI 컴포넌트 50개를 해시 검증 후 설치 | 영+한 | [threeui-skill](https://github.com/sjh9714/threeui-skill) |
 ## 🪝 Hooks
 
 | 이름 | 도구 | 설명 | 언어 | 레포 |

--- a/categories/web-frontend.md
+++ b/categories/web-frontend.md
@@ -44,7 +44,7 @@
 | impeccable-lite | CC/GC | AI 디자인 품질 향상 스킬 | 영+한 | [impeccable-lite](https://github.com/ilindaniel/impeccable-lite) |
 | auteur | CC/GC | 웹사이트를 영화처럼 연출하는 Claude Code 스킬 | 영+한 | [auteur](https://github.com/agiwhitelist/auteur) |
 | threejs-skills | CC | Claude Code를 위한 Three.js 스킬 모음 | 영+한 | [threejs-skills](https://github.com/CloudAI-X/threejs-skills) |
-| threeui | CX/CR | ThreeUI 컴포넌트 50개를 해시 검증 후 설치 | 영+한 | [threeui-skill](https://github.com/sjh9714/threeui-skill) |
+| threeui | CX/CR | ThreeUI 컴포넌트 50개를 해시 검증 후 설치 | 영+한 | [threeui-cli](https://github.com/sjh9714/threeui-cli) |
 ## 🪝 Hooks
 
 | 이름 | 도구 | 설명 | 언어 | 레포 |


### PR DESCRIPTION
ThreeUI Community 컴포넌트 50개를 Codex와 Cursor에서 설치하는 스킬을 웹 프론트엔드 목록에 추가했습니다.

현재 저장소는 일반 사용자도 바로 쓸 수 있는 `npx threeui-cli add spark-badge` 명령을 기본으로 제공합니다. 에이전트 스킬과 Python 대체 경로도 같은 저장소에 유지합니다.

빈 임시 디렉터리에서 공개 npm 패키지로 Spark Badge를 설치했고 소스와 공용 파일의 SHA-256 검증을 확인했습니다. 기존 파일은 기본적으로 덮어쓰지 않습니다. 한국어 README와 한국어 사용 예제를 포함합니다.